### PR TITLE
2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2.0.0
+* Pass `Msg -> msg` function to every that returns a `Msg`
 * Add Viewport
   * Like Browser.Dom.Viewport with max `x` and `y`
 * Add Element
@@ -16,7 +17,7 @@
 * Add Margin
   * Allows for control over all edges instead of just horizonal and vertical
 
-* Refresh on on window resize - 300ms of no change
+* Refresh elements on window resize events - 300ms of no change
 * Batch DOM lookup when adding more elements - 500ms of no change
 
 ## 1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,8 @@
 * Add Margin
   * Allows for control over all edges instead of just horizonal and vertical
 
-* Remove addElements
-* Add addElement
-
-* Throttle refresh on window resize - 300ms
-* Throttle addElement - 500ms
+* Refresh on on window resize - 300ms of no change
+* Batch DOM lookup when adding more elements - 500ms of no change
 
 ## 1.1.0
 * Add checkCustom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 2.0.0
+* Add Viewport
+  * Like Browser.Dom.Viewport with max `x` and `y`
+* Add Element
+  * Like Browser.Dom.Element without `scene` and `viewport`
+
+* Rename checkCustom -> custom
+  * Returns `a` instead of `Maybe Bool`
+* Rename check -> isInView
+* Rename checkAlt -> isInOrAboveView
+* Rename checkWithOffset -> isInViewWithMargin
+* Rename checkAltWithOffset -> isInOrAboveViewWithMargin
+
+* Add Margin
+  * Allows for control over all edges instead of just horizonal and vertical
+
+* Remove addElements
+* Add addElement
+
+* Throttle refresh on window resize - 300ms
+* Throttle addElement - 500ms
+
 ## 1.1.0
 * Add checkCustom
 
@@ -7,4 +29,4 @@
 * Fix docs
 
 ## 1.0.0
-Initial release.
+Initial release

--- a/README.md
+++ b/README.md
@@ -8,18 +8,19 @@ Detect if an element is in the current viewport
 
 Since there is currently no way of listening to scroll events in Elm you'll have to hookup a port. Below is the bit of JS that gets you the scroll position and an example on how to set it all up.
 
-### JS
+## Port
 You might want to throttle or debounce this, listening to scroll events and getting positional information can cause some performance issues.
 ```javascript
 window.addEventListener("scroll", function() {
-    var offset = [window.pageXOffset, window.pageYOffset];
+    var offset = {x: window.pageXOffset, y: window.pageYOffset};
     app.ports.onScroll.send(offset);
 }, { passive: true });
 ```
 
-### Elm
+
+## Elm
 ```elm
-port onScroll : (( Float, Float ) -> msg) -> Sub msg
+port onScroll : ({x: Float, y: Float} -> msg) -> Sub msg
 
 
 init : flags -> ( Model, Cmd Msg )
@@ -36,31 +37,30 @@ init _ =
 subscriptions : Model -> Sub Msg
 subscriptions model =
     Sub.batch
-       [ Sub.map InViewMsg <|
-           InView.subscriptions model.inView
+       [ InView.subscriptions InViewMsg model.inView
        , onScroll OnScroll
        ]
 
 
 type Msg
-    = OnScroll ( Float, Float )
+    = OnScroll { x: Float, y: Float }
     | InViewMsg InView.Msg
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
-        OnScroll ( x, y ) ->
-            ( { model | inView = InView.updateViewportOffset x y model.inView }
+        OnScroll offset ->
+            ( { model | inView = InView.updateViewportOffset offset model.inView }
             , Cmd.none
             )
 
         InViewMsg inViewMsg ->
             let
                 ( inView, inViewCmds ) =
-                    InView.update inViewMsg model.inView
+                    InView.update InViewMsg inViewMsg model.inView
             in
             ( { model | inView = inView }
-            , Cmd.map InViewMsg inViewCmds
+            , inViewCmds
             )
 ```

--- a/README.md
+++ b/README.md
@@ -1,29 +1,19 @@
 # elm-inview
-Detect if an element is in the current viewport
+Detect if an element is in the current viewport.
 
 [example live](https://rl-king.github.io/elm-inview-example/) |
 [example code](https://github.com/rl-king/elm-inview-example)
 
 ![all](https://rl-king.github.io/elm-inview-example/illustrations/All.svg)
 
+
 Since there is currently no way of listening to scroll events in Elm you'll have to hookup a port. Below is the bit of JS that gets you the scroll position and an example on how to set it all up.
 
-## Port
-You might want to throttle or debounce this, listening to scroll events and getting positional information can cause some performance issues.
-```javascript
-window.addEventListener("scroll", function() {
-    var offset = {x: window.pageXOffset, y: window.pageYOffset};
-    app.ports.onScroll.send(offset);
-}, { passive: true });
-```
-
-
-## Elm
 ```elm
 port onScroll : ({x: Float, y: Float} -> msg) -> Sub msg
 
 
-init : flags -> ( Model, Cmd Msg )
+init : () -> ( Model, Cmd Msg )
 init _ =
     let
         ( inViewModel, inViewCmds ) =
@@ -64,3 +54,12 @@ update msg model =
             , inViewCmds
             )
 ```
+
+```javascript
+window.addEventListener("scroll", function() {
+    var offset = {x: window.pageXOffset, y: window.pageYOffset};
+    app.ports.onScroll.send(offset);
+}, { passive: true });
+```
+
+You might want to throttle or debounce this, listening to scroll events and getting positional information can cause some performance issues.

--- a/elm.json
+++ b/elm.json
@@ -1,7 +1,7 @@
 {
     "type": "package",
     "name": "rl-king/elm-inview",
-    "summary": "Detect if an element is in the current viewport",
+    "summary": "Get information on an element position relative to the current viewport",
     "license": "BSD-3-Clause",
     "version": "1.1.0",
     "exposed-modules": [

--- a/src/InView.elm
+++ b/src/InView.elm
@@ -219,11 +219,7 @@ update lift msg ((State state) as state_) =
                     { state
                         | viewport =
                             { viewport
-                                | viewport =
-                                    { viewportNested
-                                        | width = toFloat width
-                                        , height = toFloat height
-                                    }
+                                | viewport = { viewportNested | width = toFloat width, height = toFloat height }
                             }
                     }
                 , addElements lift (Dict.keys state.elements)
@@ -299,7 +295,7 @@ isInOrAboveView id state =
 
 
 
--- PADDING
+-- MARGIN
 
 
 {-| -}
@@ -352,8 +348,8 @@ isInOrAboveViewWithMargin : String -> Margin -> State -> Maybe Bool
 isInOrAboveViewWithMargin id margin state =
     let
         calc { viewport } element =
-            (viewport.y - margin.top + viewport.height > element.y)
-                && (viewport.x - margin.left + viewport.width > element.x)
+            (viewport.y - margin.bottom + viewport.height > element.y)
+                && (viewport.x - margin.right + viewport.width > element.x)
     in
     custom (\a b -> Maybe.map (calc a) b) id state
 
@@ -366,8 +362,8 @@ For example `isInOrAboveViewWithMargin` is implemented like:
     isInOrAboveViewWithMargin id margin state =
         let
             calc { viewport } element =
-                (viewport.y - margin.top + viewport.height > element.y)
-                    && (viewport.x - margin.left + viewport.width > element.x)
+                (viewport.y - margin.bottom + viewport.height > element.y)
+                    && (viewport.x - margin.right + viewport.width > element.x)
         in
         custom (\a b -> Maybe.map (calc a) b) id state
 

--- a/src/InView.elm
+++ b/src/InView.elm
@@ -16,10 +16,10 @@ module InView exposing
     , custom
     )
 
-{-| Detect if an element is visible in the current viewport.
+{-| Get information on an element position relative to the current viewport.
 
 
-# Definitions
+# Definition
 
 @docs State
 @docs Viewport
@@ -88,6 +88,9 @@ type Status
 
 
 {-| Similar to Browser.Dom.Viewport with the addition of `maxX` and `maxY`.
+
+You can use `maxX` and `maxY` to check if an element has ever been in the viewport before.
+
 -}
 type alias Viewport =
     { scene :

--- a/src/InView.elm
+++ b/src/InView.elm
@@ -7,7 +7,7 @@ module InView exposing
     , update
     , updateViewportOffset
     , subscriptions
-    , addElement
+    , addElements
     , isInView
     , isInOrAboveView
     , Margin
@@ -37,7 +37,7 @@ module InView exposing
 @docs update
 @docs updateViewportOffset
 @docs subscriptions
-@docs addElement
+@docs addElements
 
 
 # Check
@@ -134,14 +134,14 @@ init lift elementIds =
     )
 
 
-{-| Track element position after you've initialized the state.
+{-| Track element positions after you've initialized the state.
 
 Use this when the page content moves around after initialization,
 like for example when images load and stuff gets pushed down.
 
 -}
-addElement : (Msg -> msg) -> String -> State -> ( State, Cmd msg )
-addElement lift id (State state) =
+addElements : (Msg -> msg) -> List String -> State -> ( State, Cmd msg )
+addElements lift ids (State state) =
     let
         upsert element =
             case element of
@@ -154,7 +154,7 @@ addElement lift id (State state) =
     ( State
         { state
             | onRefreshKey = nextKey state.onRefreshKey
-            , elements = Dict.update id upsert state.elements
+            , elements = List.foldl (\id acc -> Dict.update id upsert acc) state.elements ids
         }
     , Task.perform (\_ -> lift (Refresh (nextKey state.onRefreshKey))) <|
         Process.sleep 500
@@ -251,8 +251,8 @@ update lift msg ((State state) as state_) =
 
 
 nextKey : Key a -> Key a
-nextKey (Key onRefreshKey) =
-    Key (onRefreshKey + 1)
+nextKey (Key k) =
+    Key (k + 1)
 
 
 fromViewport : Browser.Dom.Viewport -> State -> Viewport


### PR DESCRIPTION
## 2.0.0
 * Add Viewport
   * Like Browser.Dom.Viewport with max `x` and `y`
 * Add Element
   * Like Browser.Dom.Element without `scene` and `viewport`

 * Rename checkCustom -> custom
   * Returns `a` instead of `Maybe Bool`
 * Rename check -> isInView
 * Rename checkAlt -> isInOrAboveView
 * Rename checkWithOffset -> isInViewWithMargin
 * Rename checkAltWithOffset -> isInOrAboveViewWithMargin

 * Add Margin
   * Allows for control over all edges instead of just horizonal and vertical

 * Refresh on on window resize - 300ms of no change
 * Batch DOM lookup when adding more elements - 500ms of no change